### PR TITLE
[UPD] ssi_hr_payroll_batch_operating_unit

### DIFF
--- a/ssi_hr_payroll_batch_operating_unit/models/__init__.py
+++ b/ssi_hr_payroll_batch_operating_unit/models/__init__.py
@@ -2,4 +2,5 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import hr_payslip  # noqa: F401
 from . import hr_payslip_batch  # noqa: F401

--- a/ssi_hr_payroll_batch_operating_unit/models/hr_payslip.py
+++ b/ssi_hr_payroll_batch_operating_unit/models/hr_payslip.py
@@ -1,0 +1,40 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class HrPayslip(models.Model):  # pylint: disable=too-few-public-methods
+    """
+    Extends hr.payslip with a constraint to ensure that
+    a payslip's operating_unit_id matches its batch's operating_unit_id.
+    """
+
+    _name = "hr.payslip"
+    _inherit = "hr.payslip"
+
+    @api.constrains("batch_id", "operating_unit_id")
+    def _check_batch_operating_unit(self):
+        for document in self.sudo():
+            if not document._check_payslip_batch_operating_unit_condition():
+                # pylint: disable=consider-using-f-string
+                error_message = """
+Context: Check payslip operating unit consistency with batch
+Database ID: %s
+Problem: Payslip operating unit (%s) does not match batch operating unit (%s)
+Solution: Ensure the payslip operating unit is the same as the batch operating unit
+""" % (
+                    document.id,
+                    document.operating_unit_id.name,
+                    document.batch_id.operating_unit_id.name,
+                )
+                # pylint: enable=consider-using-f-string
+                raise ValidationError(_(error_message))
+
+    def _check_payslip_batch_operating_unit_condition(self):
+        self.ensure_one()
+        if not self.batch_id:
+            return True
+        return self.operating_unit_id == self.batch_id.operating_unit_id


### PR DESCRIPTION
* Tambahkan hr_payslip.py: Python constrains untuk memastikan operating_unit_id payslip sama dengan batch
* Pisahkan kondisi ke method _check_payslip_batch_operating_unit_condition (return bool, overridable)
* Pesan error dan raise ValidationError tetap di _check_batch_operating_unit