### PR TITLE
[UPD] ssi_hr_payroll_operating_unit

### DIFF
--- a/ssi_hr_payroll_operating_unit/__manifest__.py
+++ b/ssi_hr_payroll_operating_unit/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": [
         "ssi_hr_payroll",
         "ssi_operating_unit_mixin",
+        "ssi_financial_accounting_operating_unit",
     ],
     "data": [
         "security/res_group/res_group_data.xml",

--- a/ssi_hr_payroll_operating_unit/models/hr_payslip.py
+++ b/ssi_hr_payroll_operating_unit/models/hr_payslip.py
@@ -5,11 +5,13 @@
 from odoo import models
 
 
-class HrPayslip(models.Model):  # pylint: disable=too-few-public-methods
+class HrPayslip(models.Model):
     """
     Extends hr.payslip with operating unit support.
     Adds mixin.single_operating_unit so payslip documents
     can be scoped to a specific operating unit.
+    Overrides _prepare_account_move_data to propagate operating_unit_id
+    to the generated accounting entry.
     """
 
     _name = "hr.payslip"
@@ -17,3 +19,8 @@ class HrPayslip(models.Model):  # pylint: disable=too-few-public-methods
         "hr.payslip",
         "mixin.single_operating_unit",
     ]
+
+    def _prepare_account_move_data(self):
+        res = super()._prepare_account_move_data()
+        res["operating_unit_id"] = self.operating_unit_id.id
+        return res

--- a/ssi_hr_payroll_operating_unit/tests/test_data_hr_payslip_operating_unit.yaml
+++ b/ssi_hr_payroll_operating_unit/tests/test_data_hr_payslip_operating_unit.yaml
@@ -115,3 +115,79 @@ scenarios:
           operating_unit_id:
             type: "value"
             operator: "is_truthy"
+
+      - step: "Compute payslip"
+        action: "call"
+        target: "payslip"
+        method: "action_compute_payslip"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate cache after compute"
+        action: "call"
+        target: "payslip"
+        method: "invalidate_cache"
+
+      - step: "Reload input lines"
+        action: "call"
+        target: "payslip"
+        method: "action_reload_input_lines"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate cache after reload"
+        action: "call"
+        target: "payslip"
+        method: "invalidate_cache"
+
+      - step: "Confirm payslip"
+        action: "call"
+        target: "payslip"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Invalidate cache after confirm"
+        action: "call"
+        target: "payslip"
+        method: "invalidate_cache"
+
+      - step: "Approve payslip"
+        action: "call"
+        target: "payslip"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step: "Invalidate cache after done"
+        action: "call"
+        target: "payslip"
+        method: "invalidate_cache"
+
+      - step: "Assert accounting entry created"
+        action: "assert"
+        target: "payslip"
+        asserts:
+          move_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Get account move"
+        action: "search"
+        model: "account.move"
+        domain:
+          - ["id", "=", "EVAL: registry['payslip'].move_id.id"]
+        save_as: "account_move"
+        limit: 1
+
+      - step: "Assert move has operating unit set"
+        action: "assert"
+        target: "account_move"
+        asserts:
+          operating_unit_id:
+            type: "value"
+            operator: "is_truthy"

--- a/ssi_hr_payroll_operating_unit/tests/test_hr_payslip_operating_unit.py
+++ b/ssi_hr_payroll_operating_unit/tests/test_hr_payslip_operating_unit.py
@@ -11,3 +11,10 @@ from odoo.tests import tagged
 class TestHrPayslipOperatingUnit(YamlTransactionCase):
     def test_hr_payslip_operating_unit(self):
         self.run_yaml_scenario("test_data_hr_payslip_operating_unit.yaml")
+        payslip = self.registry.get("payslip")
+        if payslip and payslip.move_id:
+            self.assertEqual(
+                payslip.move_id.operating_unit_id,
+                payslip.operating_unit_id,
+                "account.move should have the same operating_unit_id as the payslip",
+            )


### PR DESCRIPTION
* Propagate operating_unit_id to account.move created by _10_create_accounting_entry
* Add ssi_financial_accounting_operating_unit dependency
* Update test scenario to include full workflow (draft → done)
* Assert account.move.operating_unit_id matches payslip.operating_unit_id