### PR TITLE
[UPD] ssi_hr_payroll_batch_operating_unit: propagasi OU ke journal entry batch

### DIFF
--- a/ssi_hr_payroll_batch_operating_unit/models/hr_payslip_batch.py
+++ b/ssi_hr_payroll_batch_operating_unit/models/hr_payslip_batch.py
@@ -13,6 +13,8 @@ class HrPayslipBatch(models.Model):  # pylint: disable=too-few-public-methods
     Overrides _compute_employee_ids to filter allowed employees by the batch OU.
     Overrides _prepare_payslip_data to propagate operating_unit_id
     to each generated payslip.
+    Overrides _prepare_standard_move to propagate operating_unit_id
+    to the batch-level journal entry.
     """
 
     _name = "hr.payslip_batch"
@@ -40,5 +42,10 @@ class HrPayslipBatch(models.Model):  # pylint: disable=too-few-public-methods
 
     def _prepare_payslip_data(self, employee):
         res = super()._prepare_payslip_data(employee)
+        res["operating_unit_id"] = self.operating_unit_id.id
+        return res
+
+    def _prepare_standard_move(self):
+        res = super()._prepare_standard_move()
         res["operating_unit_id"] = self.operating_unit_id.id
         return res

--- a/ssi_hr_payroll_batch_operating_unit/tests/test_hr_payslip_batch_operating_unit.py
+++ b/ssi_hr_payroll_batch_operating_unit/tests/test_hr_payslip_batch_operating_unit.py
@@ -121,3 +121,140 @@ class TestHrPayslipBatchOperatingUnit(YamlTransactionCase):
             non_ou1_employees,
             "Employees with different OU must not be loaded after Reload",
         )
+
+    def _create_batch_move_ou_fixtures(self, prefix):
+        """Return fixtures for testing move operating_unit_id propagation."""
+        env = self.env
+        company = env.ref("base.main_company")
+        partner = env.ref("base.main_partner")
+        acc_type = env.ref("account.data_account_type_expenses")
+
+        ou = env["operating.unit"].create(
+            {
+                "name": "%s OU" % prefix,
+                "code": "%sOU" % prefix,
+                "partner_id": partner.id,
+                "company_id": company.id,
+            }
+        )
+        debit_acc = env["account.account"].create(
+            {
+                "name": "%s Debit" % prefix,
+                "code": "%sDB" % prefix,
+                "user_type_id": acc_type.id,
+            }
+        )
+        credit_acc = env["account.account"].create(
+            {
+                "name": "%s Credit" % prefix,
+                "code": "%sCR" % prefix,
+                "user_type_id": acc_type.id,
+            }
+        )
+        default_acc = env["account.account"].create(
+            {
+                "name": "%s Default" % prefix,
+                "code": "%sDFT" % prefix,
+                "user_type_id": acc_type.id,
+            }
+        )
+        journal = env["account.journal"].create(
+            {
+                "name": "%s Journal" % prefix,
+                "code": prefix[:4],
+                "type": "general",
+                "default_account_id": default_acc.id,
+            }
+        )
+        rule_cat = env["hr.salary_rule_category"].create(
+            {"name": "%s Cat" % prefix, "code": "%sCAT" % prefix}
+        )
+        rule = env["hr.salary_rule"].create(
+            {
+                "name": "%s Rule" % prefix,
+                "code": "%sRULE" % prefix,
+                "category_id": rule_cat.id,
+                "debit_account_id": debit_acc.id,
+                "credit_account_id": credit_acc.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 1000.0",
+                "sequence": 10,
+            }
+        )
+        structure = env["hr.salary_structure"].create(
+            {
+                "name": "%s Structure" % prefix,
+                "code": "%sSTR" % prefix,
+                "rule_ids": [(4, rule.id)],
+            }
+        )
+        payslip_type = env["hr.payslip_type"].create(
+            {
+                "name": "%s Type" % prefix,
+                "code": "%sTYPE" % prefix,
+                "accounting_method": "batch",
+                "journal_id": journal.id,
+            }
+        )
+        struct_field = (
+            "manual_salary_structure_id"
+            if "manual_salary_structure_id" in env["hr.employee"]._fields
+            else "salary_structure_id"
+        )
+        employee = env["hr.employee"].create(
+            {
+                "name": "%s Employee" % prefix,
+                struct_field: structure.id,
+                "operating_unit_id": ou.id,
+            }
+        )
+        batch = env["hr.payslip_batch"].create(
+            {
+                "type_id": payslip_type.id,
+                "accounting_method": "batch",
+                "journal_id": journal.id,
+                "date_start": "2026-05-01",
+                "date_end": "2026-05-31",
+                "date": "2026-05-31",
+                "operating_unit_id": ou.id,
+                "employee_ids": [(6, 0, [employee.id])],
+            }
+        )
+        return {"batch": batch, "ou": ou}
+
+    def _run_batch_to_done(self, batch):
+        """Drive a batch through the full approval workflow to done state."""
+        admin = self.env.ref("base.user_admin")
+        batch.with_user(admin).action_open()
+        batch.invalidate_cache()
+        batch.with_user(admin).action_compute_payslip()
+        batch.invalidate_cache()
+        batch.with_user(admin).with_context(bypass_policy_check=True).action_confirm()
+        batch.invalidate_cache()
+        batch.with_user(admin).with_context(
+            bypass_policy_check=True
+        ).action_approve_approval()
+        batch.invalidate_cache()
+
+    def test_batch_move_has_same_operating_unit_as_batch(self):
+        """_prepare_standard_move must propagate operating_unit_id to account.move.
+
+        When accounting_method is 'batch', the journal entry created at done
+        must carry the same operating_unit_id as the payslip batch.
+        """
+        f = self._create_batch_move_ou_fixtures("TMOVOU")
+        batch = f["batch"]
+        ou = f["ou"]
+
+        self._run_batch_to_done(batch)
+
+        self.assertEqual(batch.state, "done")
+        self.assertTrue(
+            batch.move_id,
+            "Batch with accounting_method=batch must have a move_id after done",
+        )
+        self.assertEqual(
+            batch.move_id.operating_unit_id,
+            ou,
+            "Journal entry operating_unit_id must match the batch operating_unit_id",
+        )


### PR DESCRIPTION
## Summary

- Override `_prepare_standard_move` di `ssi_hr_payroll_batch_operating_unit` agar `account.move` yang dibuat saat batch selesai (`accounting_method=batch`) memiliki `operating_unit_id` yang sama dengan batch-nya.
- Tambahkan unit test `test_batch_move_has_same_operating_unit_as_batch` yang memverifikasi propagasi OU ke journal entry.

## Detail Perubahan

### `models/hr_payslip_batch.py`
- Tambah override `_prepare_standard_move()` yang menambahkan `operating_unit_id` dari batch ke dict data pembuatan `account.move`.

### `tests/test_hr_payslip_batch_operating_unit.py`
- Tambah helper `_create_batch_move_ou_fixtures(prefix)` — menyiapkan OU, akun, jurnal, struktur gaji, dan karyawan.
- Tambah helper `_run_batch_to_done(batch)` — menjalankan batch melalui alur penuh hingga state `done`.
- Tambah test `test_batch_move_has_same_operating_unit_as_batch` — memverifikasi `batch.move_id.operating_unit_id == batch.operating_unit_id` setelah batch selesai.