### PR TITLE
[FIX] Selaraskan resolusi akun penjurnalan payslip dengan aturan baru

### DIFF
--- a/ssi_hr_payroll/models/hr_payslip_line.py
+++ b/ssi_hr_payroll/models/hr_payslip_line.py
@@ -85,12 +85,6 @@ class HrPayslipLine(models.Model):
 
     def _get_debit_account(self):
         self.ensure_one()
-        # Block usage from injecting a debit when the rule explicitly covers only the
-        # credit side.  Without this guard a "credit-only" rule (debit_account_id=False,
-        # credit_account_id set) would still pick up a debit account via usage and
-        # produce a spurious double-entry together with the paired "debit-only" rule.
-        if self.rule_id.credit_account_id and not self.rule_id.debit_account_id:
-            return False
         account = self._get_account_by_product_usage(self.payslip_id.debit_usage_id)
         if account:
             return account
@@ -98,12 +92,6 @@ class HrPayslipLine(models.Model):
 
     def _get_credit_account(self):
         self.ensure_one()
-        # Block usage from injecting a credit when the rule explicitly covers only the
-        # debit side.  Without this guard a "debit-only" rule (debit_account_id set,
-        # credit_account_id=False) would still pick up a credit account via usage and
-        # produce a spurious double-entry together with the paired "credit-only" rule.
-        if self.rule_id.debit_account_id and not self.rule_id.credit_account_id:
-            return False
         account = self._get_account_by_product_usage(self.payslip_id.credit_usage_id)
         if account:
             return account

--- a/ssi_hr_payroll/models/hr_payslip_line.py
+++ b/ssi_hr_payroll/models/hr_payslip_line.py
@@ -85,7 +85,11 @@ class HrPayslipLine(models.Model):
 
     def _get_debit_account(self):
         self.ensure_one()
-        if not self.rule_id.debit_account_id:
+        # Block usage from injecting a debit when the rule explicitly covers only the
+        # credit side.  Without this guard a "credit-only" rule (debit_account_id=False,
+        # credit_account_id set) would still pick up a debit account via usage and
+        # produce a spurious double-entry together with the paired "debit-only" rule.
+        if self.rule_id.credit_account_id and not self.rule_id.debit_account_id:
             return False
         account = self._get_account_by_product_usage(self.payslip_id.debit_usage_id)
         if account:
@@ -94,7 +98,11 @@ class HrPayslipLine(models.Model):
 
     def _get_credit_account(self):
         self.ensure_one()
-        if not self.rule_id.credit_account_id:
+        # Block usage from injecting a credit when the rule explicitly covers only the
+        # debit side.  Without this guard a "debit-only" rule (debit_account_id set,
+        # credit_account_id=False) would still pick up a credit account via usage and
+        # produce a spurious double-entry together with the paired "credit-only" rule.
+        if self.rule_id.debit_account_id and not self.rule_id.credit_account_id:
             return False
         account = self._get_account_by_product_usage(self.payslip_id.credit_usage_id)
         if account:

--- a/ssi_hr_payroll/models/hr_payslip_line.py
+++ b/ssi_hr_payroll/models/hr_payslip_line.py
@@ -85,6 +85,8 @@ class HrPayslipLine(models.Model):
 
     def _get_debit_account(self):
         self.ensure_one()
+        if not self.rule_id.debit_account_id:
+            return False
         account = self._get_account_by_product_usage(self.payslip_id.debit_usage_id)
         if account:
             return account
@@ -92,6 +94,8 @@ class HrPayslipLine(models.Model):
 
     def _get_credit_account(self):
         self.ensure_one()
+        if not self.rule_id.credit_account_id:
+            return False
         account = self._get_account_by_product_usage(self.payslip_id.credit_usage_id)
         if account:
             return account

--- a/ssi_hr_payroll/tests/__init__.py
+++ b/ssi_hr_payroll/tests/__init__.py
@@ -4,6 +4,7 @@
 
 from . import test_hr_payslip  # noqa: F401
 from . import test_hr_payslip_accounting_hook  # noqa: F401
+from . import test_hr_payslip_line_account_resolution  # noqa: F401
 from . import test_hr_payslip_input_type  # noqa: F401
 from . import test_hr_payslip_type  # noqa: F401
 from . import test_hr_salary_contribution  # noqa: F401

--- a/ssi_hr_payroll/tests/test_data_hr_payslip.yaml
+++ b/ssi_hr_payroll/tests/test_data_hr_payslip.yaml
@@ -949,3 +949,348 @@ scenarios:
         domain:
           - ["move_id", "=", "EVAL: registry['payslip'].move_id.id"]
           - ["analytic_account_id", "=", "EVAL: registry['analytic_account'].id"]
+
+  - name: "HR Payslip - Paired one-sided rules without usage"
+    steps:
+      - step: "Get expense account type"
+        action: "ref"
+        xml_id: "account.data_account_type_expenses"
+        save_as: "expense_account_type"
+
+      - step: "Create expense account for debit side"
+        action: "create"
+        model: "account.account"
+        save_as: "debit_account"
+        values:
+          name: "Test One-Sided Debit Account"
+          code: "TSTPSL_OS_DB"
+          user_type_id: "EVAL: registry['expense_account_type'].id"
+
+      - step: "Create payable account for credit side"
+        action: "create"
+        model: "account.account"
+        save_as: "credit_account"
+        values:
+          name: "Test One-Sided Credit Account"
+          code: "TSTPSL_OS_CR"
+          user_type_id: "EVAL: registry['expense_account_type'].id"
+
+      - step: "Create payroll journal"
+        action: "create"
+        model: "account.journal"
+        save_as: "journal"
+        values:
+          name: "Test One-Sided Journal"
+          code: "TSTOSJ"
+          type: "general"
+
+      - step: "Create salary rule category"
+        action: "create"
+        model: "hr.salary_rule_category"
+        save_as: "category"
+        values:
+          name: "Test One-Sided Category"
+          code: "TSTOSCAT"
+
+      - step: "Create debit-only salary rule"
+        action: "create"
+        model: "hr.salary_rule"
+        save_as: "rule_debit"
+        values:
+          name: "Test Debit-Only Rule"
+          code: "TSTOSDBRULE"
+          category_id: "EVAL: registry['category'].id"
+          debit_account_id: "EVAL: registry['debit_account'].id"
+          condition_python: "result = True"
+          amount_python: "result = 100.0"
+          sequence: 10
+
+      - step: "Create credit-only salary rule"
+        action: "create"
+        model: "hr.salary_rule"
+        save_as: "rule_credit"
+        values:
+          name: "Test Credit-Only Rule"
+          code: "TSTOSCRRULE"
+          category_id: "EVAL: registry['category'].id"
+          credit_account_id: "EVAL: registry['credit_account'].id"
+          condition_python: "result = True"
+          amount_python: "result = 100.0"
+          sequence: 20
+
+      - step: "Create salary structure with both one-sided rules"
+        action: "create"
+        model: "hr.salary_structure"
+        save_as: "structure"
+        values:
+          name: "Test One-Sided Structure"
+          code: "TSTOSSTR"
+          rule_ids:
+            - "EVAL: registry['rule_debit'].id"
+            - "EVAL: registry['rule_credit'].id"
+
+      - step: "Create payslip type without usage"
+        action: "create"
+        model: "hr.payslip_type"
+        save_as: "payslip_type"
+        values:
+          name: "Test One-Sided Payslip Type"
+          code: "TSTOSTYPE"
+          journal_id: "EVAL: registry['journal'].id"
+
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Test One-Sided Employee"
+          salary_structure_id: "EVAL: registry['structure'].id"
+
+      - step: "Create payslip without usage"
+        action: "create"
+        model: "hr.payslip"
+        save_as: "payslip"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "EVAL: registry['employee'].id"
+          type_id: "EVAL: registry['payslip_type'].id"
+          structure_id: "EVAL: registry['structure'].id"
+          journal_id: "EVAL: registry['journal'].id"
+          date_start: "2024-06-01"
+          date_end: "2024-06-30"
+          date: "2024-06-30"
+
+      - step: "Compute payslip"
+        action: "call"
+        target: "payslip"
+        method: "action_compute_payslip"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate cache after compute"
+        action: "call"
+        target: "payslip"
+        method: "invalidate_cache"
+
+      - step: "Confirm payslip"
+        action: "call"
+        target: "payslip"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Invalidate cache after confirm"
+        action: "call"
+        target: "payslip"
+        method: "invalidate_cache"
+
+      - step: "Approve payslip to done"
+        action: "call"
+        target: "payslip"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step: "Invalidate cache after done"
+        action: "call"
+        target: "payslip"
+        method: "invalidate_cache"
+
+      - step: "Assert accounting entry created"
+        action: "assert"
+        target: "payslip"
+        asserts:
+          move_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert exactly one debit AML on debit account"
+        action: "search"
+        model: "account.move.line"
+        save_as: "debit_lines"
+        expect_count: 1
+        domain:
+          - ["move_id", "=", "EVAL: registry['payslip'].move_id.id"]
+          - ["account_id", "=", "EVAL: registry['debit_account'].id"]
+          - ["debit", ">", 0.0]
+
+      - step: "Assert exactly one credit AML on credit account"
+        action: "search"
+        model: "account.move.line"
+        save_as: "credit_lines"
+        expect_count: 1
+        domain:
+          - ["move_id", "=", "EVAL: registry['payslip'].move_id.id"]
+          - ["account_id", "=", "EVAL: registry['credit_account'].id"]
+          - ["credit", ">", 0.0]
+
+  - name: "HR Payslip - Unbalanced triggers adjustment"
+    steps:
+      - step: "Get expense account type"
+        action: "ref"
+        xml_id: "account.data_account_type_expenses"
+        save_as: "expense_account_type"
+
+      - step: "Create expense account for debit side"
+        action: "create"
+        model: "account.account"
+        save_as: "debit_account"
+        values:
+          name: "Test Unbalanced Debit Account"
+          code: "TSTPSL_UB_DB"
+          user_type_id: "EVAL: registry['expense_account_type'].id"
+
+      - step: "Create default account for journal balancing"
+        action: "create"
+        model: "account.account"
+        save_as: "default_account"
+        values:
+          name: "Test Unbalanced Default Account"
+          code: "TSTPSL_UB_DEF"
+          user_type_id: "EVAL: registry['expense_account_type'].id"
+
+      - step: "Create journal with default account"
+        action: "create"
+        model: "account.journal"
+        save_as: "journal"
+        values:
+          name: "Test Unbalanced Journal"
+          code: "TSTUBJRN"
+          type: "general"
+          default_account_id: "EVAL: registry['default_account'].id"
+
+      - step: "Create salary rule category"
+        action: "create"
+        model: "hr.salary_rule_category"
+        save_as: "category"
+        values:
+          name: "Test Unbalanced Category"
+          code: "TSTUBCAT"
+
+      - step: "Create debit-only salary rule (no credit side)"
+        action: "create"
+        model: "hr.salary_rule"
+        save_as: "rule"
+        values:
+          name: "Test Unbalanced Rule"
+          code: "TSTUBRULE"
+          category_id: "EVAL: registry['category'].id"
+          debit_account_id: "EVAL: registry['debit_account'].id"
+          condition_python: "result = True"
+          amount_python: "result = 100.0"
+          sequence: 10
+
+      - step: "Create salary structure"
+        action: "create"
+        model: "hr.salary_structure"
+        save_as: "structure"
+        values:
+          name: "Test Unbalanced Structure"
+          code: "TSTUBSTR"
+          rule_ids:
+            - "EVAL: registry['rule'].id"
+
+      - step: "Create payslip type"
+        action: "create"
+        model: "hr.payslip_type"
+        save_as: "payslip_type"
+        values:
+          name: "Test Unbalanced Payslip Type"
+          code: "TSTUBTYPE"
+          journal_id: "EVAL: registry['journal'].id"
+
+      - step: "Create employee"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Test Unbalanced Employee"
+          salary_structure_id: "EVAL: registry['structure'].id"
+
+      - step: "Create payslip"
+        action: "create"
+        model: "hr.payslip"
+        save_as: "payslip"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "EVAL: registry['employee'].id"
+          type_id: "EVAL: registry['payslip_type'].id"
+          structure_id: "EVAL: registry['structure'].id"
+          journal_id: "EVAL: registry['journal'].id"
+          date_start: "2024-07-01"
+          date_end: "2024-07-31"
+          date: "2024-07-31"
+
+      - step: "Compute payslip"
+        action: "call"
+        target: "payslip"
+        method: "action_compute_payslip"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate cache after compute"
+        action: "call"
+        target: "payslip"
+        method: "invalidate_cache"
+
+      - step: "Confirm payslip"
+        action: "call"
+        target: "payslip"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Invalidate cache after confirm"
+        action: "call"
+        target: "payslip"
+        method: "invalidate_cache"
+
+      - step: "Approve payslip to done"
+        action: "call"
+        target: "payslip"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step: "Invalidate cache after done"
+        action: "call"
+        target: "payslip"
+        method: "invalidate_cache"
+
+      - step: "Assert accounting entry created"
+        action: "assert"
+        target: "payslip"
+        asserts:
+          move_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert debit AML on debit account"
+        action: "search"
+        model: "account.move.line"
+        save_as: "debit_lines"
+        expect_count: 1
+        domain:
+          - ["move_id", "=", "EVAL: registry['payslip'].move_id.id"]
+          - ["account_id", "=", "EVAL: registry['debit_account'].id"]
+          - ["debit", ">", 0.0]
+
+      - step: "Assert adjustment AML on journal default account"
+        action: "search"
+        model: "account.move.line"
+        save_as: "adj_lines"
+        expect_count: 1
+        domain:
+          - ["move_id", "=", "EVAL: registry['payslip'].move_id.id"]
+          - ["account_id", "=", "EVAL: registry['default_account'].id"]
+          - ["credit", ">", 0.0]

--- a/ssi_hr_payroll/tests/test_hr_payslip_line_account_resolution.py
+++ b/ssi_hr_payroll/tests/test_hr_payslip_line_account_resolution.py
@@ -7,17 +7,15 @@ from odoo.tests import TransactionCase, tagged
 
 @tagged("post_install", "-at_install")
 class TestHrPayslipLineAccountResolution(TransactionCase):
-    """Regression tests for double-journaling bug in payslip line account resolution.
+    """Tests for payslip line account resolution (_get_debit_account / _get_credit_account).
 
-    The fix only blocks usage resolution when the rule is *asymmetric* — i.e. it has
-    one side's account set but not the other.  When the rule has neither fixed account,
-    usage is still the sole source for both sides (full-usage mode).
-
-    Scenario that triggered the bug (SGRS): two paired rules:
-      - Rule A (debit-only): debit_account_id=736, credit_account_id=False
-      - Rule B (credit-only): debit_account_id=False, credit_account_id=568
-    Before the fix, usage injected a credit AML for Rule A and a debit AML for Rule B,
-    so the expense account was debited twice instead of once.
+    Design rule (confirmed by user):
+      - Debit: usage resolves via payslip.debit_usage_id + rule.product_id →
+        fallback to rule.debit_account_id → if neither → no debit line.
+      - Credit: usage resolves via payslip.credit_usage_id + rule.product_id →
+        fallback to rule.credit_account_id → if neither → no credit line.
+      - No guard based on whether the rule has the "opposite" fixed account.
+        A debit-only rule can still obtain a credit account via usage (and vice versa).
     """
 
     def setUp(self):
@@ -46,8 +44,7 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
             }
         )
 
-        # Usage type: any product + code "TSLRUSE" resolves to account_usage
-        # via the fallback chain in _get_product_account().
+        # Usage type that RESOLVES: falls through to usage_type.account_id.
         self.usage = self.env["product.usage_type"].create(
             {
                 "name": "Test Line Resolution Usage Type",
@@ -56,8 +53,18 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
             }
         )
 
-        # Minimal product without product-specific account mapping so that
-        # _get_product_account() falls through to the usage type's own account.
+        # Usage type that does NOT resolve: no account_id, no product mapping.
+        # _get_product_account("TSLREMPTY") returns False for our product.
+        self.usage_no_account = self.env["product.usage_type"].create(
+            {
+                "name": "Test Line Resolution Empty Usage",
+                "code": "TSLREMPTY",
+            }
+        )
+
+        # Minimal product: no product.account record, so resolution falls through
+        # to usage_type.account_id (which is why self.usage resolves but
+        # self.usage_no_account does not).
         product_tmpl = self.env["product.template"].create(
             {
                 "name": "Test Line Resolution Product",
@@ -149,9 +156,9 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
             }
         )
 
-        # Create payslip with debit_usage_id and credit_usage_id explicitly set,
-        # simulating a payslip type that uses usage-based account resolution.
         admin = self.env.ref("base.user_admin")
+
+        # Main payslip: both debit_usage_id and credit_usage_id resolve.
         self.payslip = (
             self.env["hr.payslip"]
             .with_user(admin)
@@ -170,6 +177,43 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
             )
         )
 
+        # Payslip with NO usage set on either side.
+        self.payslip_no_usage = (
+            self.env["hr.payslip"]
+            .with_user(admin)
+            .create(
+                {
+                    "employee_id": employee.id,
+                    "type_id": payslip_type.id,
+                    "structure_id": structure.id,
+                    "journal_id": journal.id,
+                    "date_start": "2024-02-01",
+                    "date_end": "2024-02-28",
+                    "date": "2024-02-28",
+                }
+            )
+        )
+
+        # Payslip with usage that cannot resolve any account.
+        self.payslip_empty_usage = (
+            self.env["hr.payslip"]
+            .with_user(admin)
+            .create(
+                {
+                    "employee_id": employee.id,
+                    "type_id": payslip_type.id,
+                    "structure_id": structure.id,
+                    "journal_id": journal.id,
+                    "date_start": "2024-03-01",
+                    "date_end": "2024-03-31",
+                    "date": "2024-03-31",
+                    "debit_usage_id": self.usage_no_account.id,
+                    "credit_usage_id": self.usage_no_account.id,
+                }
+            )
+        )
+
+        # Lines on main payslip (usage resolves for both sides).
         self.line_usage_only = self.env["hr.payslip_line"].create(
             {
                 "payslip_id": self.payslip.id,
@@ -179,7 +223,6 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
                 "rate": 100.0,
             }
         )
-
         self.line_debit_only = self.env["hr.payslip_line"].create(
             {
                 "payslip_id": self.payslip.id,
@@ -189,7 +232,6 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
                 "rate": 100.0,
             }
         )
-
         self.line_credit_only = self.env["hr.payslip_line"].create(
             {
                 "payslip_id": self.payslip.id,
@@ -200,67 +242,98 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
             }
         )
 
+        # Lines on empty-usage payslip (usage present but does not resolve).
+        self.line_debit_only_empty_usage = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip_empty_usage.id,
+                "rule_id": self.rule_debit_only.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+        self.line_usage_only_empty_usage = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip_empty_usage.id,
+                "rule_id": self.rule_usage_only.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+        self.line_credit_only_empty_usage = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip_empty_usage.id,
+                "rule_id": self.rule_credit_only.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+
+        # Lines on no-usage payslip (usage not set at all).
+        self.line_debit_only_no_usage = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip_no_usage.id,
+                "rule_id": self.rule_debit_only.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+        self.line_usage_only_no_usage = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip_no_usage.id,
+                "rule_id": self.rule_usage_only.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+        self.line_credit_only_no_usage = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip_no_usage.id,
+                "rule_id": self.rule_credit_only.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Sanity                                                              #
+    # ------------------------------------------------------------------ #
+
     def test_usage_resolves_account_via_fallback(self):
         """Sanity: _get_account_by_product_usage returns the usage type account."""
         account = self.product._get_product_account(self.usage.code)
         self.assertTrue(account)
 
-    def test_debit_only_rule_returns_false_for_credit_even_when_usage_resolves(self):
-        """Regression: credit must be False when rule has no credit_account_id.
+    def test_empty_usage_does_not_resolve(self):
+        """Sanity: usage_no_account resolves to False for our product."""
+        account = self.product._get_product_account(self.usage_no_account.code)
+        self.assertFalse(account)
 
-        Proves that usage resolution is blocked by the guard in _get_credit_account()
-        even when _get_account_by_product_usage() would successfully return an account.
-        """
-        # Verify usage CAN resolve an account — confirming the guard is the blocker.
-        usage_account = self.line_debit_only._get_account_by_product_usage(
-            self.payslip.credit_usage_id
-        )
-        self.assertTrue(
-            usage_account, "Usage should resolve an account for this product"
-        )
-
-        # The fix: _get_credit_account() must return False because credit_account_id
-        # is not set on the rule, regardless of what usage resolves.
-        result = self.line_debit_only._get_credit_account()
-        self.assertFalse(
-            result,
-            "_get_credit_account() must return False when rule has no credit_account_id",
-        )
+    # ------------------------------------------------------------------ #
+    #  Positive: fixed accounts are returned when usage does not resolve  #
+    # ------------------------------------------------------------------ #
 
     def test_debit_only_rule_returns_account_for_debit(self):
-        """Positive: _get_debit_account() returns an account when debit_account_id is set."""
+        """Positive: _get_debit_account() returns debit_account_id when set."""
         result = self.line_debit_only._get_debit_account()
         self.assertTrue(result)
 
-    def test_credit_only_rule_returns_false_for_debit_even_when_usage_resolves(self):
-        """Regression: debit must be False when rule has no debit_account_id.
-
-        Proves that usage resolution is blocked by the guard in _get_debit_account()
-        even when _get_account_by_product_usage() would successfully return an account.
-        """
-        # Verify usage CAN resolve an account — confirming the guard is the blocker.
-        usage_account = self.line_credit_only._get_account_by_product_usage(
-            self.payslip.debit_usage_id
-        )
-        self.assertTrue(
-            usage_account, "Usage should resolve an account for this product"
-        )
-
-        # The fix: _get_debit_account() must return False because debit_account_id
-        # is not set on the rule, regardless of what usage resolves.
-        result = self.line_credit_only._get_debit_account()
-        self.assertFalse(
-            result,
-            "_get_debit_account() must return False when rule has no debit_account_id",
-        )
-
     def test_credit_only_rule_returns_account_for_credit(self):
-        """Positive: _get_credit_account() returns an account when credit_account_id is set."""
+        """Positive: _get_credit_account() returns credit_account_id when set."""
         result = self.line_credit_only._get_credit_account()
         self.assertTrue(result)
 
+    # ------------------------------------------------------------------ #
+    #  Full-usage mode (rule without fixed accounts)                       #
+    # ------------------------------------------------------------------ #
+
     def test_no_fixed_account_rule_resolves_debit_via_usage(self):
-        """Full-usage mode: rule with no fixed accounts can still resolve debit via usage."""
+        """Full-usage mode: rule with no fixed accounts resolves debit via usage."""
         result = self.line_usage_only._get_debit_account()
         self.assertTrue(
             result,
@@ -268,9 +341,251 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
         )
 
     def test_no_fixed_account_rule_resolves_credit_via_usage(self):
-        """Full-usage mode: rule with no fixed accounts can still resolve credit via usage."""
+        """Full-usage mode: rule with no fixed accounts resolves credit via usage."""
         result = self.line_usage_only._get_credit_account()
         self.assertTrue(
             result,
             "_get_credit_account() must resolve via usage when rule has no fixed accounts",
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Cross-side: usage prevails even when only the opposite fixed        #
+    #  account is set on the rule (new design, replaces old guard tests)  #
+    # ------------------------------------------------------------------ #
+
+    def test_debit_only_rule_returns_credit_via_usage(self):
+        """Usage takes priority: debit-only rule still gets credit account via usage.
+
+        With the new design there is no guard that blocks usage on the side that
+        lacks a fixed account. A debit-only rule (credit_account_id=False) CAN obtain
+        a credit account via credit_usage_id + product_id on the payslip.
+        """
+        usage_account = self.line_debit_only._get_account_by_product_usage(
+            self.payslip.credit_usage_id
+        )
+        self.assertTrue(usage_account, "Precondition: usage must resolve an account")
+
+        result = self.line_debit_only._get_credit_account()
+        self.assertTrue(
+            result,
+            "_get_credit_account() must return the usage account for a debit-only rule "
+            "when credit_usage_id + product_id resolve an account",
+        )
+
+    def test_credit_only_rule_returns_debit_via_usage(self):
+        """Usage takes priority: credit-only rule still gets debit account via usage.
+
+        A credit-only rule (debit_account_id=False) CAN obtain a debit account
+        via debit_usage_id + product_id on the payslip.
+        """
+        usage_account = self.line_credit_only._get_account_by_product_usage(
+            self.payslip.debit_usage_id
+        )
+        self.assertTrue(usage_account, "Precondition: usage must resolve an account")
+
+        result = self.line_credit_only._get_debit_account()
+        self.assertTrue(
+            result,
+            "_get_debit_account() must return the usage account for a credit-only rule "
+            "when debit_usage_id + product_id resolve an account",
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Fallback matrix — DEBIT side                                        #
+    # ------------------------------------------------------------------ #
+
+    def test_fallback_debit_usage_no_resolve_has_fixed_returns_fixed(self):
+        """Debit fallback: usage present but unresolvable → falls to debit_account_id."""
+        result = self.line_debit_only_empty_usage._get_debit_account()
+        self.assertEqual(
+            result,
+            self.account_debit,
+            "Must fall back to rule.debit_account_id when usage cannot resolve",
+        )
+
+    def test_fallback_debit_usage_no_resolve_no_fixed_returns_false(self):
+        """Debit fallback: usage present but unresolvable + no fixed → False."""
+        result = self.line_usage_only_empty_usage._get_debit_account()
+        self.assertFalse(
+            result,
+            "_get_debit_account() must return False when neither usage nor fixed resolves",
+        )
+
+    def test_fallback_debit_no_usage_has_fixed_returns_fixed(self):
+        """Debit fallback: no usage set → falls to debit_account_id."""
+        result = self.line_debit_only_no_usage._get_debit_account()
+        self.assertEqual(
+            result,
+            self.account_debit,
+            "Must return rule.debit_account_id when no usage is set on the payslip",
+        )
+
+    def test_fallback_debit_no_usage_no_fixed_returns_false(self):
+        """Debit fallback: no usage set + no fixed account → False."""
+        result = self.line_usage_only_no_usage._get_debit_account()
+        self.assertFalse(
+            result,
+            "_get_debit_account() must return False when no usage and no fixed account",
+        )
+
+    def test_fallback_debit_no_product_usage_present_has_fixed_returns_fixed(self):
+        """Debit fallback: rule has no product_id → usage skipped → falls to fixed."""
+        rule_cat = self.env["hr.salary_rule_category"].search(
+            [("code", "=", "TSLRCAT")], limit=1
+        )
+        rule = self.env["hr.salary_rule"].create(
+            {
+                "name": "No Product Debit Only",
+                "code": "TSLRNPDB01",
+                "category_id": rule_cat.id,
+                "debit_account_id": self.account_debit.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 100.0",
+                "sequence": 99,
+            }
+        )
+        line = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip.id,
+                "rule_id": rule.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+        result = line._get_debit_account()
+        self.assertEqual(
+            result,
+            self.account_debit,
+            "Must return rule.debit_account_id when rule has no product_id",
+        )
+
+    def test_fallback_debit_no_product_no_fixed_returns_false(self):
+        """Debit fallback: rule has no product_id + no fixed account → False."""
+        rule_cat = self.env["hr.salary_rule_category"].search(
+            [("code", "=", "TSLRCAT")], limit=1
+        )
+        rule = self.env["hr.salary_rule"].create(
+            {
+                "name": "No Product No Fixed",
+                "code": "TSLRNPNF01",
+                "category_id": rule_cat.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 100.0",
+                "sequence": 99,
+            }
+        )
+        line = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip.id,
+                "rule_id": rule.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+        result = line._get_debit_account()
+        self.assertFalse(
+            result,
+            "_get_debit_account() must return False when no product_id and no fixed account",
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Fallback matrix — CREDIT side (symmetric)                           #
+    # ------------------------------------------------------------------ #
+
+    def test_fallback_credit_usage_no_resolve_has_fixed_returns_fixed(self):
+        """Credit fallback: usage present but unresolvable → falls to credit_account_id."""
+        result = self.line_credit_only_empty_usage._get_credit_account()
+        self.assertEqual(
+            result,
+            self.account_credit,
+            "Must fall back to rule.credit_account_id when usage cannot resolve",
+        )
+
+    def test_fallback_credit_usage_no_resolve_no_fixed_returns_false(self):
+        """Credit fallback: usage present but unresolvable + no fixed → False."""
+        result = self.line_usage_only_empty_usage._get_credit_account()
+        self.assertFalse(
+            result,
+            "_get_credit_account() must return False when neither usage nor fixed resolves",
+        )
+
+    def test_fallback_credit_no_usage_has_fixed_returns_fixed(self):
+        """Credit fallback: no usage set → falls to credit_account_id."""
+        result = self.line_credit_only_no_usage._get_credit_account()
+        self.assertEqual(
+            result,
+            self.account_credit,
+            "Must return rule.credit_account_id when no usage is set on the payslip",
+        )
+
+    def test_fallback_credit_no_usage_no_fixed_returns_false(self):
+        """Credit fallback: no usage set + no fixed account → False."""
+        result = self.line_usage_only_no_usage._get_credit_account()
+        self.assertFalse(
+            result,
+            "_get_credit_account() must return False when no usage and no fixed account",
+        )
+
+    def test_fallback_credit_no_product_usage_present_has_fixed_returns_fixed(self):
+        """Credit fallback: rule has no product_id → usage skipped → falls to fixed."""
+        rule_cat = self.env["hr.salary_rule_category"].search(
+            [("code", "=", "TSLRCAT")], limit=1
+        )
+        rule = self.env["hr.salary_rule"].create(
+            {
+                "name": "No Product Credit Only",
+                "code": "TSLRNPCR01",
+                "category_id": rule_cat.id,
+                "credit_account_id": self.account_credit.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 100.0",
+                "sequence": 99,
+            }
+        )
+        line = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip.id,
+                "rule_id": rule.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+        result = line._get_credit_account()
+        self.assertEqual(
+            result,
+            self.account_credit,
+            "Must return rule.credit_account_id when rule has no product_id",
+        )
+
+    def test_fallback_credit_no_product_no_fixed_returns_false(self):
+        """Credit fallback: rule has no product_id + no fixed account → False."""
+        rule_cat = self.env["hr.salary_rule_category"].search(
+            [("code", "=", "TSLRCAT")], limit=1
+        )
+        rule = self.env["hr.salary_rule"].create(
+            {
+                "name": "No Product No Fixed Credit",
+                "code": "TSLRNPNFC01",
+                "category_id": rule_cat.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 100.0",
+                "sequence": 99,
+            }
+        )
+        line = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip.id,
+                "rule_id": rule.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+        result = line._get_credit_account()
+        self.assertFalse(
+            result,
+            "_get_credit_account() must return False when no product_id and no fixed account",
         )

--- a/ssi_hr_payroll/tests/test_hr_payslip_line_account_resolution.py
+++ b/ssi_hr_payroll/tests/test_hr_payslip_line_account_resolution.py
@@ -9,15 +9,15 @@ from odoo.tests import TransactionCase, tagged
 class TestHrPayslipLineAccountResolution(TransactionCase):
     """Regression tests for double-journaling bug in payslip line account resolution.
 
-    When a salary rule has only debit_account_id (no credit_account_id), and the
-    payslip has credit_usage_id set, _get_credit_account() must still return False.
-    And vice versa.
+    The fix only blocks usage resolution when the rule is *asymmetric* — i.e. it has
+    one side's account set but not the other.  When the rule has neither fixed account,
+    usage is still the sole source for both sides (full-usage mode).
 
-    Before the fix, usage resolution in _get_debit_account() / _get_credit_account()
-    would create AMLs for the side that has no account on the rule, causing each paired
-    rule (e.g. "BPJS Perusahaan" + "Iuran BPJS") to independently generate a full
-    double-entry instead of together forming one — resulting in double-journaling of
-    the expense.
+    Scenario that triggered the bug (SGRS): two paired rules:
+      - Rule A (debit-only): debit_account_id=736, credit_account_id=False
+      - Rule B (credit-only): debit_account_id=False, credit_account_id=568
+    Before the fix, usage injected a credit AML for Rule A and a debit AML for Rule B,
+    so the expense account was debited twice instead of once.
     """
 
     def setUp(self):
@@ -73,6 +73,19 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
             }
         )
 
+        # Rule with NO fixed accounts — relies entirely on usage for both sides.
+        self.rule_usage_only = self.env["hr.salary_rule"].create(
+            {
+                "name": "Test Line Resolution Usage Only",
+                "code": "TSLRUSEONLY",
+                "category_id": rule_cat.id,
+                "product_id": self.product.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 100.0",
+                "sequence": 5,
+            }
+        )
+
         # Rule with ONLY debit_account_id — credit_account_id intentionally absent.
         self.rule_debit_only = self.env["hr.salary_rule"].create(
             {
@@ -106,6 +119,7 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
                 "name": "Test Line Resolution Structure",
                 "code": "TSLRSTR",
                 "rule_ids": [
+                    (4, self.rule_usage_only.id),
                     (4, self.rule_debit_only.id),
                     (4, self.rule_credit_only.id),
                 ],
@@ -154,6 +168,16 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
                     "credit_usage_id": self.usage.id,
                 }
             )
+        )
+
+        self.line_usage_only = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip.id,
+                "rule_id": self.rule_usage_only.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
         )
 
         self.line_debit_only = self.env["hr.payslip_line"].create(
@@ -234,3 +258,19 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
         """Positive: _get_credit_account() returns an account when credit_account_id is set."""
         result = self.line_credit_only._get_credit_account()
         self.assertTrue(result)
+
+    def test_no_fixed_account_rule_resolves_debit_via_usage(self):
+        """Full-usage mode: rule with no fixed accounts can still resolve debit via usage."""
+        result = self.line_usage_only._get_debit_account()
+        self.assertTrue(
+            result,
+            "_get_debit_account() must resolve via usage when rule has no fixed accounts",
+        )
+
+    def test_no_fixed_account_rule_resolves_credit_via_usage(self):
+        """Full-usage mode: rule with no fixed accounts can still resolve credit via usage."""
+        result = self.line_usage_only._get_credit_account()
+        self.assertTrue(
+            result,
+            "_get_credit_account() must resolve via usage when rule has no fixed accounts",
+        )

--- a/ssi_hr_payroll/tests/test_hr_payslip_line_account_resolution.py
+++ b/ssi_hr_payroll/tests/test_hr_payslip_line_account_resolution.py
@@ -1,0 +1,236 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHrPayslipLineAccountResolution(TransactionCase):
+    """Regression tests for double-journaling bug in payslip line account resolution.
+
+    When a salary rule has only debit_account_id (no credit_account_id), and the
+    payslip has credit_usage_id set, _get_credit_account() must still return False.
+    And vice versa.
+
+    Before the fix, usage resolution in _get_debit_account() / _get_credit_account()
+    would create AMLs for the side that has no account on the rule, causing each paired
+    rule (e.g. "BPJS Perusahaan" + "Iuran BPJS") to independently generate a full
+    double-entry instead of together forming one — resulting in double-journaling of
+    the expense.
+    """
+
+    def setUp(self):
+        super().setUp()
+        expense_type = self.env.ref("account.data_account_type_expenses")
+
+        self.account_debit = self.env["account.account"].create(
+            {
+                "name": "Test Line Resolution Debit",
+                "code": "TSLRDB01",
+                "user_type_id": expense_type.id,
+            }
+        )
+        self.account_credit = self.env["account.account"].create(
+            {
+                "name": "Test Line Resolution Credit",
+                "code": "TSLRCR01",
+                "user_type_id": expense_type.id,
+            }
+        )
+        account_usage = self.env["account.account"].create(
+            {
+                "name": "Test Line Resolution Usage",
+                "code": "TSLRUS01",
+                "user_type_id": expense_type.id,
+            }
+        )
+
+        # Usage type: any product + code "TSLRUSE" resolves to account_usage
+        # via the fallback chain in _get_product_account().
+        self.usage = self.env["product.usage_type"].create(
+            {
+                "name": "Test Line Resolution Usage Type",
+                "code": "TSLRUSE",
+                "account_id": account_usage.id,
+            }
+        )
+
+        # Minimal product without product-specific account mapping so that
+        # _get_product_account() falls through to the usage type's own account.
+        product_tmpl = self.env["product.template"].create(
+            {
+                "name": "Test Line Resolution Product",
+                "type": "service",
+            }
+        )
+        self.product = product_tmpl.product_variant_ids[0]
+
+        rule_cat = self.env["hr.salary_rule_category"].create(
+            {
+                "name": "Test Line Resolution Cat",
+                "code": "TSLRCAT",
+            }
+        )
+
+        # Rule with ONLY debit_account_id — credit_account_id intentionally absent.
+        self.rule_debit_only = self.env["hr.salary_rule"].create(
+            {
+                "name": "Test Line Resolution Debit Only",
+                "code": "TSLRDBONLY",
+                "category_id": rule_cat.id,
+                "debit_account_id": self.account_debit.id,
+                "product_id": self.product.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 100.0",
+                "sequence": 10,
+            }
+        )
+
+        # Rule with ONLY credit_account_id — debit_account_id intentionally absent.
+        self.rule_credit_only = self.env["hr.salary_rule"].create(
+            {
+                "name": "Test Line Resolution Credit Only",
+                "code": "TSLRCRONLY",
+                "category_id": rule_cat.id,
+                "credit_account_id": self.account_credit.id,
+                "product_id": self.product.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 100.0",
+                "sequence": 20,
+            }
+        )
+
+        structure = self.env["hr.salary_structure"].create(
+            {
+                "name": "Test Line Resolution Structure",
+                "code": "TSLRSTR",
+                "rule_ids": [
+                    (4, self.rule_debit_only.id),
+                    (4, self.rule_credit_only.id),
+                ],
+            }
+        )
+
+        employee = self.env["hr.employee"].create(
+            {
+                "name": "Test Line Resolution Employee",
+                "salary_structure_id": structure.id,
+            }
+        )
+
+        journal = self.env["account.journal"].create(
+            {
+                "name": "Test Line Resolution Journal",
+                "code": "TSLRJRN",
+                "type": "general",
+            }
+        )
+
+        payslip_type = self.env["hr.payslip_type"].create(
+            {
+                "name": "Test Line Resolution Type",
+                "code": "TSLRTYPE",
+                "journal_id": journal.id,
+            }
+        )
+
+        # Create payslip with debit_usage_id and credit_usage_id explicitly set,
+        # simulating a payslip type that uses usage-based account resolution.
+        admin = self.env.ref("base.user_admin")
+        self.payslip = (
+            self.env["hr.payslip"]
+            .with_user(admin)
+            .create(
+                {
+                    "employee_id": employee.id,
+                    "type_id": payslip_type.id,
+                    "structure_id": structure.id,
+                    "journal_id": journal.id,
+                    "date_start": "2024-01-01",
+                    "date_end": "2024-01-31",
+                    "date": "2024-01-31",
+                    "debit_usage_id": self.usage.id,
+                    "credit_usage_id": self.usage.id,
+                }
+            )
+        )
+
+        self.line_debit_only = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip.id,
+                "rule_id": self.rule_debit_only.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+
+        self.line_credit_only = self.env["hr.payslip_line"].create(
+            {
+                "payslip_id": self.payslip.id,
+                "rule_id": self.rule_credit_only.id,
+                "amount": 100.0,
+                "quantity": 1.0,
+                "rate": 100.0,
+            }
+        )
+
+    def test_usage_resolves_account_via_fallback(self):
+        """Sanity: _get_account_by_product_usage returns the usage type account."""
+        account = self.product._get_product_account(self.usage.code)
+        self.assertTrue(account)
+
+    def test_debit_only_rule_returns_false_for_credit_even_when_usage_resolves(self):
+        """Regression: credit must be False when rule has no credit_account_id.
+
+        Proves that usage resolution is blocked by the guard in _get_credit_account()
+        even when _get_account_by_product_usage() would successfully return an account.
+        """
+        # Verify usage CAN resolve an account — confirming the guard is the blocker.
+        usage_account = self.line_debit_only._get_account_by_product_usage(
+            self.payslip.credit_usage_id
+        )
+        self.assertTrue(
+            usage_account, "Usage should resolve an account for this product"
+        )
+
+        # The fix: _get_credit_account() must return False because credit_account_id
+        # is not set on the rule, regardless of what usage resolves.
+        result = self.line_debit_only._get_credit_account()
+        self.assertFalse(
+            result,
+            "_get_credit_account() must return False when rule has no credit_account_id",
+        )
+
+    def test_debit_only_rule_returns_account_for_debit(self):
+        """Positive: _get_debit_account() returns an account when debit_account_id is set."""
+        result = self.line_debit_only._get_debit_account()
+        self.assertTrue(result)
+
+    def test_credit_only_rule_returns_false_for_debit_even_when_usage_resolves(self):
+        """Regression: debit must be False when rule has no debit_account_id.
+
+        Proves that usage resolution is blocked by the guard in _get_debit_account()
+        even when _get_account_by_product_usage() would successfully return an account.
+        """
+        # Verify usage CAN resolve an account — confirming the guard is the blocker.
+        usage_account = self.line_credit_only._get_account_by_product_usage(
+            self.payslip.debit_usage_id
+        )
+        self.assertTrue(
+            usage_account, "Usage should resolve an account for this product"
+        )
+
+        # The fix: _get_debit_account() must return False because debit_account_id
+        # is not set on the rule, regardless of what usage resolves.
+        result = self.line_credit_only._get_debit_account()
+        self.assertFalse(
+            result,
+            "_get_debit_account() must return False when rule has no debit_account_id",
+        )
+
+    def test_credit_only_rule_returns_account_for_credit(self):
+        """Positive: _get_credit_account() returns an account when credit_account_id is set."""
+        result = self.line_credit_only._get_credit_account()
+        self.assertTrue(result)

--- a/ssi_hr_payroll_batch/models/hr_payslip_batch.py
+++ b/ssi_hr_payroll_batch/models/hr_payslip_batch.py
@@ -541,12 +541,14 @@ and required fields
             debit_ml, credit_ml = entry._create_standard_ml()
             entry.write(
                 {
-                    "debit_move_line_id": debit_ml.id,
-                    "credit_move_line_id": credit_ml.id,
+                    "debit_move_line_id": debit_ml.id if debit_ml else False,
+                    "credit_move_line_id": credit_ml.id if credit_ml else False,
                 }
             )
-            debit_sum += debit_ml.debit - debit_ml.credit
-            credit_sum += credit_ml.credit - credit_ml.debit
+            if debit_ml:
+                debit_sum += debit_ml.debit - debit_ml.credit
+            if credit_ml:
+                credit_sum += credit_ml.credit - credit_ml.debit
         self._create_balance_adjustment(debit_sum, credit_sum)
         self._post_standard_move()
         self._reconcile_batch_account_entry()
@@ -597,7 +599,9 @@ and required fields
             groups[key]["amount"] += line.amount
         Entry = self.env["hr.payslip_batch_account_entry"]
         for vals in groups.values():
-            if vals["amount"]:
+            if vals["amount"] and (
+                vals["debit_account_id"] or vals["credit_account_id"]
+            ):
                 vals["batch_id"] = self.id
                 Entry.create(vals)
 

--- a/ssi_hr_payroll_batch/models/hr_payslip_batch_account_entry.py
+++ b/ssi_hr_payroll_batch/models/hr_payslip_batch_account_entry.py
@@ -132,6 +132,17 @@ class HrPayslipBatchAccountEntry(models.Model):
         help="Company currency inherited from the batch.",
     )
 
+    def _create_standard_ml(self):
+        self.ensure_one()
+        ML = self.env["account.move.line"].with_context(check_move_validity=False)
+        debit_ml = self.env["account.move.line"]
+        credit_ml = self.env["account.move.line"]
+        if self.debit_account_id:
+            debit_ml = ML.create(self._prepare_standard_ml("debit"))
+        if self.credit_account_id:
+            credit_ml = ML.create(self._prepare_standard_ml("credit"))
+        return debit_ml, credit_ml
+
     def _reconcile_debit(self, candidate_ml):
         """Reconcile the debit move line against candidate reference lines."""
         self.ensure_one()

--- a/ssi_hr_payroll_batch/tests/test_hr_payslip_batch_journaling.py
+++ b/ssi_hr_payroll_batch/tests/test_hr_payslip_batch_journaling.py
@@ -384,3 +384,161 @@ class TestHrPayslipBatchJournaling(YamlTransactionCase):
             }
         )
         self.assertEqual(batch.accounting_method, "payslip")
+
+    # ------------------------------------------------------------------ #
+    #  Task 4C: regression — paired one-sided rules without usage          #
+    # ------------------------------------------------------------------ #
+
+    def _create_one_sided_batch_fixtures(self):
+        """Fixtures for paired one-sided rules (debit-only + credit-only) with no usage."""
+        env = self.env
+        acc_type = env.ref("account.data_account_type_expenses")
+
+        debit_acc = env["account.account"].create(
+            {"name": "OS Debit", "code": "OSDB01", "user_type_id": acc_type.id}
+        )
+        credit_acc = env["account.account"].create(
+            {"name": "OS Credit", "code": "OSCR01", "user_type_id": acc_type.id}
+        )
+        default_acc = env["account.account"].create(
+            {"name": "OS Default", "code": "OSDFT01", "user_type_id": acc_type.id}
+        )
+        journal = env["account.journal"].create(
+            {
+                "name": "OS Journal",
+                "code": "OSJRN",
+                "type": "general",
+                "default_account_id": default_acc.id,
+            }
+        )
+        rule_cat = env["hr.salary_rule_category"].create(
+            {"name": "OS Cat", "code": "OSCAT"}
+        )
+        rule_debit = env["hr.salary_rule"].create(
+            {
+                "name": "OS Debit-Only Rule",
+                "code": "OSDBRULE",
+                "category_id": rule_cat.id,
+                "debit_account_id": debit_acc.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 500.0",
+                "sequence": 10,
+            }
+        )
+        rule_credit = env["hr.salary_rule"].create(
+            {
+                "name": "OS Credit-Only Rule",
+                "code": "OSCRRULE",
+                "category_id": rule_cat.id,
+                "credit_account_id": credit_acc.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 500.0",
+                "sequence": 20,
+            }
+        )
+        structure = env["hr.salary_structure"].create(
+            {
+                "name": "OS Structure",
+                "code": "OSSTR",
+                "rule_ids": [(4, rule_debit.id), (4, rule_credit.id)],
+            }
+        )
+        payslip_type = env["hr.payslip_type"].create(
+            {
+                "name": "OS Type",
+                "code": "OSTYPE",
+                "accounting_method": "batch",
+                "journal_id": journal.id,
+            }
+        )
+        struct_field = (
+            "manual_salary_structure_id"
+            if "manual_salary_structure_id" in env["hr.employee"]._fields
+            else "salary_structure_id"
+        )
+        employee = env["hr.employee"].create(
+            {"name": "OS Employee", struct_field: structure.id}
+        )
+        batch = env["hr.payslip_batch"].create(
+            {
+                "type_id": payslip_type.id,
+                "accounting_method": "batch",
+                "journal_id": journal.id,
+                "date_start": "2026-05-01",
+                "date_end": "2026-05-31",
+                "date": "2026-05-31",
+                "employee_ids": [(6, 0, [employee.id])],
+            }
+        )
+        return {
+            "batch": batch,
+            "journal": journal,
+            "debit_acc": debit_acc,
+            "credit_acc": credit_acc,
+            "default_acc": default_acc,
+            "rule_debit": rule_debit,
+            "rule_credit": rule_credit,
+        }
+
+    def test_20_paired_one_sided_rules_no_aml_with_false_account(self):
+        """Regression Task 4C: paired one-sided rules → no AML with account_id=False.
+
+        Proves that _create_standard_ml() override correctly skips the missing side
+        instead of creating an AML with account_id=False (which would fail action_post).
+        """
+        f = self._create_one_sided_batch_fixtures()
+        batch = f["batch"]
+        self._run_batch_to_done(batch)
+
+        self.assertEqual(batch.state, "done")
+        self.assertTrue(batch.move_id)
+        self.assertEqual(batch.move_id.state, "posted")
+
+        false_account_lines = batch.move_id.line_ids.filtered(
+            lambda l: not l.account_id
+        )
+        self.assertFalse(
+            false_account_lines,
+            "Batch move must not contain any AML with account_id=False",
+        )
+
+    def test_21_paired_one_sided_rules_correct_aml_sides(self):
+        """Regression Task 4C: debit-only → 1 debit AML; credit-only → 1 credit AML."""
+        f = self._create_one_sided_batch_fixtures()
+        batch = f["batch"]
+        self._run_batch_to_done(batch)
+
+        move_lines = batch.move_id.line_ids
+        debit_lines = move_lines.filtered(
+            lambda l: l.account_id == f["debit_acc"] and l.debit > 0
+        )
+        credit_lines = move_lines.filtered(
+            lambda l: l.account_id == f["credit_acc"] and l.credit > 0
+        )
+        self.assertEqual(
+            len(debit_lines),
+            1,
+            "Must have exactly one debit AML on the debit account",
+        )
+        self.assertEqual(
+            len(credit_lines),
+            1,
+            "Must have exactly one credit AML on the credit account",
+        )
+        self.assertAlmostEqual(debit_lines[0].debit, 500.0, places=2)
+        self.assertAlmostEqual(credit_lines[0].credit, 500.0, places=2)
+
+    def test_22_paired_one_sided_rules_move_balanced(self):
+        """Regression Task 4C: paired one-sided rules produce a balanced batch move."""
+        f = self._create_one_sided_batch_fixtures()
+        batch = f["batch"]
+        self._run_batch_to_done(batch)
+
+        total_debit = sum(batch.move_id.line_ids.mapped("debit"))
+        total_credit = sum(batch.move_id.line_ids.mapped("credit"))
+        self.assertAlmostEqual(
+            total_debit,
+            total_credit,
+            places=2,
+            msg="Batch move must be balanced for paired one-sided rules",
+        )


### PR DESCRIPTION
## Ringkasan

* **`ssi_hr_payroll`**: Hapus guard asimetris dari `_get_debit_account()` / `_get_credit_account()` yang ditambahkan sebelumnya. Guard tersebut melanggar aturan desain yang diinginkan — usage harus selalu diutamakan tanpa blokade berdasarkan akun sisi lawan.
* **`ssi_hr_payroll_batch`**: Override `_create_standard_ml()` di `hr.payslip_batch_account_entry` agar hanya membuat sisi AML yang akunnya terisi; perbaiki akumulasi sum terhadap recordset kosong; filter entry orphan tanpa akun.

## Aturan resolusi akun yang diimplementasikan

1. Debit: `debit_usage_id` + `product_id` → fallback `debit_account_id` → skip jika keduanya kosong.
2. Credit: `credit_usage_id` + `product_id` → fallback `credit_account_id` → skip jika keduanya kosong.
3. Tidak ada guard berdasarkan akun sisi lawan — proteksi double-journal menjadi tanggung jawab konfigurasi `debit_usage_id`/`credit_usage_id` di payslip type.

## Test yang ditambahkan / diubah

**`ssi_hr_payroll`**
- 2 test method yang assertionnya berlawanan dengan aturan baru dibalik
- 14 test baru untuk matriks fallback debit/credit (usage resolve, usage tidak resolve, tanpa usage, tanpa product)
- 2 skenario YAML baru: paired one-sided rules tanpa usage + unbalanced triggers adjustment

**`ssi_hr_payroll_batch`**
- 3 test regresi: paired one-sided rules menghasilkan move tanpa AML `account_id=False`, AML pada sisi yang benar, dan move balance

## Rencana test

- [ ] CI green untuk `ssi_hr_payroll`
- [ ] CI green untuk `ssi_hr_payroll_batch`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)