### PR TITLE
[FIX] ssi_hr_payroll & ssi_hr_payroll_batch: gate akun + cleanup entry batch

### DIFF
--- a/ssi_hr_payroll/models/hr_payslip_line.py
+++ b/ssi_hr_payroll/models/hr_payslip_line.py
@@ -85,17 +85,29 @@ class HrPayslipLine(models.Model):
 
     def _get_debit_account(self):
         self.ensure_one()
-        account = self._get_account_by_product_usage(self.payslip_id.debit_usage_id)
-        if account:
-            return account
-        return self.rule_id.debit_account_id
+        debit_account = self.rule_id.debit_account_id
+        if not debit_account:
+            return debit_account
+        if self.payslip_id.debit_usage_id:
+            usage_account = self._get_account_by_product_usage(
+                self.payslip_id.debit_usage_id
+            )
+            if usage_account:
+                return usage_account
+        return debit_account
 
     def _get_credit_account(self):
         self.ensure_one()
-        account = self._get_account_by_product_usage(self.payslip_id.credit_usage_id)
-        if account:
-            return account
-        return self.rule_id.credit_account_id
+        credit_account = self.rule_id.credit_account_id
+        if not credit_account:
+            return credit_account
+        if self.payslip_id.credit_usage_id:
+            usage_account = self._get_account_by_product_usage(
+                self.payslip_id.credit_usage_id
+            )
+            if usage_account:
+                return usage_account
+        return credit_account
 
     def _prepare_aml_debit_data(self, move):
         self.ensure_one()

--- a/ssi_hr_payroll/tests/test_data_hr_payslip.yaml
+++ b/ssi_hr_payroll/tests/test_data_hr_payslip.yaml
@@ -599,6 +599,24 @@ scenarios:
           code: "TSTUSG_CR"
           user_type_id: "EVAL: registry['expense_account_type'].id"
 
+      - step: "Create debit gate account (fixed on rule, overridden by usage)"
+        action: "create"
+        model: "account.account"
+        save_as: "debit_gate_account"
+        values:
+          name: "Test Usage Debit Gate Account"
+          code: "TSTUSG_DBG"
+          user_type_id: "EVAL: registry['expense_account_type'].id"
+
+      - step: "Create credit gate account (fixed on rule, overridden by usage)"
+        action: "create"
+        model: "account.account"
+        save_as: "credit_gate_account"
+        values:
+          name: "Test Usage Credit Gate Account"
+          code: "TSTUSG_CRG"
+          user_type_id: "EVAL: registry['expense_account_type'].id"
+
       - step: "Create debit usage type"
         action: "create"
         model: "product.usage_type"
@@ -659,7 +677,7 @@ scenarios:
           name: "Test Category Usage"
           code: "TSTPSLCATU"
 
-      - step: "Create salary rule with product but no fixed accounts"
+      - step: "Create salary rule with product and gate accounts (usage overrides)"
         action: "create"
         model: "hr.salary_rule"
         save_as: "rule"
@@ -668,6 +686,8 @@ scenarios:
           code: "TSTPSLRULEU"
           category_id: "EVAL: registry['category'].id"
           product_id: "EVAL: registry['product'].id"
+          debit_account_id: "EVAL: registry['debit_gate_account'].id"
+          credit_account_id: "EVAL: registry['credit_gate_account'].id"
           condition_python: "result = True"
           amount_python: "result = 100.0"
           sequence: 10

--- a/ssi_hr_payroll/tests/test_hr_payslip_line_account_resolution.py
+++ b/ssi_hr_payroll/tests/test_hr_payslip_line_account_resolution.py
@@ -9,13 +9,14 @@ from odoo.tests import TransactionCase, tagged
 class TestHrPayslipLineAccountResolution(TransactionCase):
     """Tests for payslip line account resolution (_get_debit_account / _get_credit_account).
 
-    Design rule (confirmed by user):
-      - Debit: usage resolves via payslip.debit_usage_id + rule.product_id →
-        fallback to rule.debit_account_id → if neither → no debit line.
-      - Credit: usage resolves via payslip.credit_usage_id + rule.product_id →
-        fallback to rule.credit_account_id → if neither → no credit line.
-      - No guard based on whether the rule has the "opposite" fixed account.
-        A debit-only rule can still obtain a credit account via usage (and vice versa).
+    Design rule (confirmed by user) — fixed account is a per-side GATE:
+      - Debit: rule.debit_account_id is the gate. If empty → no debit line at all,
+        even when usage could resolve. If set: when payslip.debit_usage_id is filled,
+        resolve the account via usage (falling back to debit_account_id when usage
+        cannot resolve); when no usage is filled, use debit_account_id directly.
+      - Credit: symmetric with rule.credit_account_id + payslip.credit_usage_id.
+      - Consequence: a rule with no fixed account on a side never journals that side;
+        usage only OVERRIDES which account is used when the gate is present.
     """
 
     def setUp(self):
@@ -36,7 +37,7 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
                 "user_type_id": expense_type.id,
             }
         )
-        account_usage = self.env["account.account"].create(
+        self.account_usage = self.env["account.account"].create(
             {
                 "name": "Test Line Resolution Usage",
                 "code": "TSLRUS01",
@@ -49,7 +50,7 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
             {
                 "name": "Test Line Resolution Usage Type",
                 "code": "TSLRUSE",
-                "account_id": account_usage.id,
+                "account_id": self.account_usage.id,
             }
         )
 
@@ -319,75 +320,98 @@ class TestHrPayslipLineAccountResolution(TransactionCase):
     # ------------------------------------------------------------------ #
 
     def test_debit_only_rule_returns_account_for_debit(self):
-        """Positive: _get_debit_account() returns debit_account_id when set."""
+        """Positive: gate present + usage resolves → usage account OVERRIDES fixed.
+
+        rule_debit_only has debit_account_id (gate) and self.payslip has a
+        debit_usage_id that resolves to self.account_usage. The usage account must
+        win over the fixed debit_account_id.
+        """
         result = self.line_debit_only._get_debit_account()
-        self.assertTrue(result)
+        self.assertEqual(
+            result,
+            self.account_usage,
+            "Usage account must override the fixed debit_account_id when the gate is set",
+        )
 
     def test_credit_only_rule_returns_account_for_credit(self):
-        """Positive: _get_credit_account() returns credit_account_id when set."""
+        """Positive: gate present + usage resolves → usage account OVERRIDES fixed."""
         result = self.line_credit_only._get_credit_account()
-        self.assertTrue(result)
+        self.assertEqual(
+            result,
+            self.account_usage,
+            "Usage account must override the fixed credit_account_id when the gate is set",
+        )
 
     # ------------------------------------------------------------------ #
-    #  Full-usage mode (rule without fixed accounts)                       #
+    #  Gate semantics: no fixed account on a side → no line for that side, #
+    #  even when usage could resolve (new design)                          #
     # ------------------------------------------------------------------ #
 
-    def test_no_fixed_account_rule_resolves_debit_via_usage(self):
-        """Full-usage mode: rule with no fixed accounts resolves debit via usage."""
+    def test_no_fixed_account_rule_returns_false_for_debit_even_when_usage_resolves(
+        self,
+    ):
+        """Gate empty: rule without debit_account_id → no debit line, despite usage."""
+        usage_account = self.line_usage_only._get_account_by_product_usage(
+            self.payslip.debit_usage_id
+        )
+        self.assertTrue(usage_account, "Precondition: usage must resolve an account")
+
         result = self.line_usage_only._get_debit_account()
-        self.assertTrue(
+        self.assertFalse(
             result,
-            "_get_debit_account() must resolve via usage when rule has no fixed accounts",
+            "_get_debit_account() must return False when the rule has no "
+            "debit_account_id gate, even if usage resolves",
         )
 
-    def test_no_fixed_account_rule_resolves_credit_via_usage(self):
-        """Full-usage mode: rule with no fixed accounts resolves credit via usage."""
+    def test_no_fixed_account_rule_returns_false_for_credit_even_when_usage_resolves(
+        self,
+    ):
+        """Gate empty: rule without credit_account_id → no credit line, despite usage."""
+        usage_account = self.line_usage_only._get_account_by_product_usage(
+            self.payslip.credit_usage_id
+        )
+        self.assertTrue(usage_account, "Precondition: usage must resolve an account")
+
         result = self.line_usage_only._get_credit_account()
-        self.assertTrue(
+        self.assertFalse(
             result,
-            "_get_credit_account() must resolve via usage when rule has no fixed accounts",
+            "_get_credit_account() must return False when the rule has no "
+            "credit_account_id gate, even if usage resolves",
         )
 
     # ------------------------------------------------------------------ #
-    #  Cross-side: usage prevails even when only the opposite fixed        #
-    #  account is set on the rule (new design, replaces old guard tests)  #
+    #  Cross-side: the opposite side's gate is empty → no line for that    #
+    #  side, even when usage could resolve (gate replaces the old guard)   #
     # ------------------------------------------------------------------ #
 
-    def test_debit_only_rule_returns_credit_via_usage(self):
-        """Usage takes priority: debit-only rule still gets credit account via usage.
-
-        With the new design there is no guard that blocks usage on the side that
-        lacks a fixed account. A debit-only rule (credit_account_id=False) CAN obtain
-        a credit account via credit_usage_id + product_id on the payslip.
-        """
+    def test_debit_only_rule_returns_false_for_credit_without_gate(self):
+        """Gate empty on credit side: debit-only rule (credit_account_id=False) must
+        NOT obtain a credit account via usage."""
         usage_account = self.line_debit_only._get_account_by_product_usage(
             self.payslip.credit_usage_id
         )
         self.assertTrue(usage_account, "Precondition: usage must resolve an account")
 
         result = self.line_debit_only._get_credit_account()
-        self.assertTrue(
+        self.assertFalse(
             result,
-            "_get_credit_account() must return the usage account for a debit-only rule "
-            "when credit_usage_id + product_id resolve an account",
+            "_get_credit_account() must return False for a debit-only rule: the "
+            "credit_account_id gate is empty, so usage is ignored",
         )
 
-    def test_credit_only_rule_returns_debit_via_usage(self):
-        """Usage takes priority: credit-only rule still gets debit account via usage.
-
-        A credit-only rule (debit_account_id=False) CAN obtain a debit account
-        via debit_usage_id + product_id on the payslip.
-        """
+    def test_credit_only_rule_returns_false_for_debit_without_gate(self):
+        """Gate empty on debit side: credit-only rule (debit_account_id=False) must
+        NOT obtain a debit account via usage."""
         usage_account = self.line_credit_only._get_account_by_product_usage(
             self.payslip.debit_usage_id
         )
         self.assertTrue(usage_account, "Precondition: usage must resolve an account")
 
         result = self.line_credit_only._get_debit_account()
-        self.assertTrue(
+        self.assertFalse(
             result,
-            "_get_debit_account() must return the usage account for a credit-only rule "
-            "when debit_usage_id + product_id resolve an account",
+            "_get_debit_account() must return False for a credit-only rule: the "
+            "debit_account_id gate is empty, so usage is ignored",
         )
 
     # ------------------------------------------------------------------ #

--- a/ssi_hr_payroll_batch/models/hr_payslip_batch.py
+++ b/ssi_hr_payroll_batch/models/hr_payslip_batch.py
@@ -558,22 +558,24 @@ and required fields
     @ssi_decorator.post_cancel_action()
     def _xx_cancel_accounting_entry(self):
         self.ensure_one()
-        if not self.move_id:
-            return True
-        self._unreconcile_batch_account_entry()
-        self.account_entry_ids.write(
-            {
-                "debit_move_line_id": False,
-                "credit_move_line_id": False,
-            }
-        )
-        self.write(
-            {
-                "move_line_debit_id": False,
-                "move_line_credit_id": False,
-            }
-        )
-        self._delete_standard_move()
+        if self.move_id:
+            self._unreconcile_batch_account_entry()
+            self.account_entry_ids.write(
+                {
+                    "debit_move_line_id": False,
+                    "credit_move_line_id": False,
+                }
+            )
+            self.write(
+                {
+                    "move_line_debit_id": False,
+                    "move_line_credit_id": False,
+                }
+            )
+            self._delete_standard_move()
+        # Always drop the entries on cancel, even when there is no move (e.g. a
+        # batch whose rules are all gate-empty). They are regenerated from scratch
+        # by _prepare_batch_account_entries on the next journaling run.
         self.account_entry_ids.unlink()
 
     # -- aggregation helpers --

--- a/ssi_hr_payroll_batch/tests/test_hr_payslip_batch_journaling.py
+++ b/ssi_hr_payroll_batch/tests/test_hr_payslip_batch_journaling.py
@@ -542,3 +542,204 @@ class TestHrPayslipBatchJournaling(YamlTransactionCase):
             places=2,
             msg="Batch move must be balanced for paired one-sided rules",
         )
+
+    # ------------------------------------------------------------------ #
+    #  Gate semantics regression (fixed account = per-side gate)           #
+    # ------------------------------------------------------------------ #
+
+    def _create_gate_batch_fixtures(self):
+        """Fixtures with batch usage + two rules:
+
+        - rule_gate: has product + both fixed gate accounts; the batch usage
+          resolves to DISTINCT usage accounts, so usage OVERRIDES the gate accounts.
+        - rule_nogate: has product (usage resolves to its own accounts) but NO fixed
+          accounts → under gate semantics it must NOT journal any side.
+        """
+        env = self.env
+        acc_type = env.ref("account.data_account_type_expenses")
+
+        def _acc(name, code):
+            return env["account.account"].create(
+                {"name": name, "code": code, "user_type_id": acc_type.id}
+            )
+
+        gate_debit = _acc("GT Gate Debit", "GTGDB")
+        gate_credit = _acc("GT Gate Credit", "GTGCR")
+        usage_debit = _acc("GT Usage Debit", "GTUDB")
+        usage_credit = _acc("GT Usage Credit", "GTUCR")
+        nogate_usage_debit = _acc("GT NoGate Usage Debit", "GTNDB")
+        nogate_usage_credit = _acc("GT NoGate Usage Credit", "GTNCR")
+        default_acc = _acc("GT Default", "GTDFT")
+
+        journal = env["account.journal"].create(
+            {
+                "name": "GT Journal",
+                "code": "GTJRN",
+                "type": "general",
+                "default_account_id": default_acc.id,
+            }
+        )
+        debit_usage = env["product.usage_type"].create(
+            {"name": "GT Debit Usage", "code": "GTUSGDB", "account_id": usage_debit.id}
+        )
+        credit_usage = env["product.usage_type"].create(
+            {
+                "name": "GT Credit Usage",
+                "code": "GTUSGCR",
+                "account_id": usage_credit.id,
+            }
+        )
+        product_gate = env["product.product"].create({"name": "GT Product Gate"})
+        product_nogate = env["product.product"].create({"name": "GT Product NoGate"})
+        # product_gate resolves to the shared usage accounts.
+        env["product.account"].create(
+            {
+                "product_id": product_gate.id,
+                "usage_id": debit_usage.id,
+                "account_id": usage_debit.id,
+            }
+        )
+        env["product.account"].create(
+            {
+                "product_id": product_gate.id,
+                "usage_id": credit_usage.id,
+                "account_id": usage_credit.id,
+            }
+        )
+        # product_nogate resolves to its OWN accounts (used to prove they never appear).
+        env["product.account"].create(
+            {
+                "product_id": product_nogate.id,
+                "usage_id": debit_usage.id,
+                "account_id": nogate_usage_debit.id,
+            }
+        )
+        env["product.account"].create(
+            {
+                "product_id": product_nogate.id,
+                "usage_id": credit_usage.id,
+                "account_id": nogate_usage_credit.id,
+            }
+        )
+        rule_cat = env["hr.salary_rule_category"].create(
+            {"name": "GT Cat", "code": "GTCAT"}
+        )
+        rule_gate = env["hr.salary_rule"].create(
+            {
+                "name": "GT Gate Rule",
+                "code": "GTGATERULE",
+                "category_id": rule_cat.id,
+                "product_id": product_gate.id,
+                "debit_account_id": gate_debit.id,
+                "credit_account_id": gate_credit.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 1000.0",
+                "sequence": 10,
+            }
+        )
+        rule_nogate = env["hr.salary_rule"].create(
+            {
+                "name": "GT NoGate Rule",
+                "code": "GTNOGATERULE",
+                "category_id": rule_cat.id,
+                "product_id": product_nogate.id,
+                "condition_python": "result = True",
+                "amount_python": "result = 700.0",
+                "sequence": 20,
+            }
+        )
+        structure = env["hr.salary_structure"].create(
+            {
+                "name": "GT Structure",
+                "code": "GTSTR",
+                "rule_ids": [(4, rule_gate.id), (4, rule_nogate.id)],
+            }
+        )
+        payslip_type = env["hr.payslip_type"].create(
+            {
+                "name": "GT Type",
+                "code": "GTTYPE",
+                "accounting_method": "batch",
+                "journal_id": journal.id,
+                "debit_usage_id": debit_usage.id,
+                "credit_usage_id": credit_usage.id,
+            }
+        )
+        struct_field = (
+            "manual_salary_structure_id"
+            if "manual_salary_structure_id" in env["hr.employee"]._fields
+            else "salary_structure_id"
+        )
+        employee = env["hr.employee"].create(
+            {"name": "GT Employee", struct_field: structure.id}
+        )
+        batch = env["hr.payslip_batch"].create(
+            {
+                "type_id": payslip_type.id,
+                "accounting_method": "batch",
+                "journal_id": journal.id,
+                "debit_usage_id": debit_usage.id,
+                "credit_usage_id": credit_usage.id,
+                "date_start": "2026-06-01",
+                "date_end": "2026-06-30",
+                "date": "2026-06-30",
+                "employee_ids": [(6, 0, [employee.id])],
+            }
+        )
+        return {
+            "batch": batch,
+            "gate_debit": gate_debit,
+            "gate_credit": gate_credit,
+            "usage_debit": usage_debit,
+            "usage_credit": usage_credit,
+            "nogate_usage_debit": nogate_usage_debit,
+            "nogate_usage_credit": nogate_usage_credit,
+        }
+
+    def test_23_usage_overrides_gate_account_in_batch(self):
+        """Gate present + batch usage resolves → entry uses the USAGE account, not gate."""
+        f = self._create_gate_batch_fixtures()
+        batch = f["batch"]
+        self._run_batch_to_done(batch)
+
+        self.assertEqual(batch.move_id.state, "posted")
+        move_lines = batch.move_id.line_ids
+
+        self.assertTrue(
+            move_lines.filtered(
+                lambda l: l.account_id == f["usage_debit"] and l.debit > 0
+            ),
+            "Debit AML must land on the usage account, overriding the gate account",
+        )
+        self.assertTrue(
+            move_lines.filtered(
+                lambda l: l.account_id == f["usage_credit"] and l.credit > 0
+            ),
+            "Credit AML must land on the usage account, overriding the gate account",
+        )
+        self.assertFalse(
+            move_lines.filtered(
+                lambda l: l.account_id in (f["gate_debit"] + f["gate_credit"])
+            ),
+            "Gate accounts must NOT appear when usage resolves",
+        )
+
+    def test_24_no_gate_rule_does_not_journal_in_batch(self):
+        """Gate empty: a rule without fixed accounts must NOT journal any side,
+        even though its product usage resolves an account."""
+        f = self._create_gate_batch_fixtures()
+        batch = f["batch"]
+        self._run_batch_to_done(batch)
+
+        move_lines = batch.move_id.line_ids
+        self.assertFalse(
+            move_lines.filtered(lambda l: not l.account_id),
+            "Batch move must not contain any AML with account_id=False",
+        )
+        self.assertFalse(
+            move_lines.filtered(
+                lambda l: l.account_id
+                in (f["nogate_usage_debit"] + f["nogate_usage_credit"])
+            ),
+            "A rule without a fixed-account gate must not journal, even when usage resolves",
+        )

--- a/ssi_hr_payroll_batch/tests/test_hr_payslip_batch_journaling.py
+++ b/ssi_hr_payroll_batch/tests/test_hr_payslip_batch_journaling.py
@@ -240,6 +240,10 @@ class TestHrPayslipBatchJournaling(YamlTransactionCase):
         self.assertFalse(batch.move_id, "Batch move_id should be cleared after cancel")
         move_exists = self.env["account.move"].search([("id", "=", move_id)])
         self.assertFalse(move_exists, "account.move should be deleted after cancel")
+        self.assertFalse(
+            batch.account_entry_ids,
+            "Batch account entries should be deleted after cancel",
+        )
 
     # ------------------------------------------------------------------ #
     #  Test 9: cancel → restart → done re-journals cleanly               #
@@ -743,3 +747,36 @@ class TestHrPayslipBatchJournaling(YamlTransactionCase):
             ),
             "A rule without a fixed-account gate must not journal, even when usage resolves",
         )
+
+    def test_25_cancel_deletes_entries_even_without_move(self):
+        """Cancel must drop account entries even when the batch has no move_id.
+
+        Guards the early-return removal in _xx_cancel_accounting_entry: an entry
+        attached to a batch with no move (so it can never be cleaned via the move
+        path) must still be unlinked on cancel, so it is regenerated from scratch
+        on the next journaling run.
+        """
+        f = self._create_batch_journaling_fixtures("T25", n_employees=1)
+        batch = f["batch"]
+
+        entry = self.env["hr.payslip_batch_account_entry"].create(
+            {
+                "batch_id": batch.id,
+                "rule_id": f["rule"].id,
+                "debit_account_id": f["debit_acc"].id,
+                "credit_account_id": f["credit_acc"].id,
+                "amount": 100.0,
+            }
+        )
+        batch.invalidate_cache()
+        self.assertTrue(batch.account_entry_ids)
+        self.assertFalse(batch.move_id, "Precondition: batch has no move yet")
+
+        batch._xx_cancel_accounting_entry()
+        batch.invalidate_cache()
+
+        self.assertFalse(
+            entry.exists(),
+            "Entry must be deleted on cancel even when the batch has no move",
+        )
+        self.assertFalse(batch.account_entry_ids)


### PR DESCRIPTION
Revisi mekanisme resolusi akun penjurnalan payslip & batch, plus cleanup entry batch saat cancel.

## ssi_hr_payroll
Jadikan `debit_account_id`/`credit_account_id` sebagai **gate per-sisi** pada resolusi akun jurnal (`_get_debit_account`/`_get_credit_account`):
- Gate kosong → sisi tidak dijurnal, walau usage bisa resolve.
- Gate ada + usage diisi → akun diambil via usage (override); bila usage gagal resolve → fallback ke fixed account.
- Gate ada + usage tidak diisi → pakai fixed account.

Membalik prioritas sebelumnya (usage-first, fixed-as-fallback). Konsekuensi: rule full-usage (tanpa fixed account) tidak lagi menjurnal.

## ssi_hr_payroll_batch
- Tambah test regresi gate semantics (test_23 override, test_24 gate kosong tak menjurnal).
- **Pastikan `account_entry_ids` selalu dihapus saat batch di-cancel**: hapus early-return `if not self.move_id` di `_xx_cancel_accounting_entry`. Entry kini selalu di-unlink dan digenerate ulang oleh `_prepare_batch_account_entries` pada penjurnalan berikutnya. Ditambah test_08 (entry kosong setelah cancel) & test_25 (entry terhapus walau batch tanpa move_id).

Semua test lolos lokal: ssi_hr_payroll 30/30, ssi_hr_payroll_batch 23/23.